### PR TITLE
Fix subnet's parsings

### DIFF
--- a/lib/fog/aws/parsers/compute/create_subnet.rb
+++ b/lib/fog/aws/parsers/compute/create_subnet.rb
@@ -7,6 +7,10 @@ module Fog
             @subnet = { 'tagSet' => {} }
             @response = { 'subnet' => [] }
             @tag = {}
+            @ipv6_cidr_block_association = {}
+            @in_tag_set = false
+            @in_ipv6_cidr_block_association_set = false
+            @in_cidr_block_state = false
           end
 
           def start_element(name, attrs = [])
@@ -14,19 +18,42 @@ module Fog
             case name
             when 'tagSet'
               @in_tag_set = true
+            when 'ipv6CidrBlockAssociationSet'
+              @in_ipv6_cidr_block_association_set = true
+            when 'ipv6CidrBlockState'
+              @in_cidr_block_state = true
             end
           end
 
           def end_element(name)
             if @in_tag_set
               case name
+              when 'item'
+                @subnet['tagSet'][@tag['key']] = @tag['value']
+                @tag = {}
+              when 'key', 'value'
+                @tag[name] = value
+              when 'tagSet'
+                @in_tag_set = false
+              end
+            elsif @in_ipv6_cidr_block_association_set
+              if @in_cidr_block_state
+                case name
+                when 'state'
+                  @ipv6_cidr_block_association['ipv6CidrBlockState'] = { name => value }
+                when 'ipv6CidrBlockState'
+                  @in_cidr_block_state = false
+                end
+              else
+                case name
                 when 'item'
-                  @subnet['tagSet'][@tag['key']] = @tag['value']
-                  @tag = {}
-                when 'key', 'value'
-                  @tag[name] = value
-                when 'tagSet'
-                  @in_tag_set = false
+                  @subnet['ipv6CidrBlockAssociationSet'] = @ipv6_cidr_block_association
+                  @ipv6_cidr_block_association = {}
+                when 'ipv6CidrBlock', 'associationId'
+                  @ipv6_cidr_block_association[name] = value
+                when 'ipv6CidrBlockAssociationSet'
+                  @in_ipv6_cidr_block_association_set = false
+                end
               end
             else
               case name

--- a/lib/fog/aws/parsers/compute/describe_subnets.rb
+++ b/lib/fog/aws/parsers/compute/describe_subnets.rb
@@ -7,6 +7,10 @@ module Fog
             @subnet = { 'tagSet' => {} }
             @response = { 'subnetSet' => [] }
             @tag = {}
+            @ipv6_cidr_block_association = {}
+            @in_tag_set = false
+            @in_ipv6_cidr_block_association_set = false
+            @in_cidr_block_state = false
           end
 
           def start_element(name, attrs = [])
@@ -14,19 +18,42 @@ module Fog
             case name
             when 'tagSet'
               @in_tag_set = true
+            when 'ipv6CidrBlockAssociationSet'
+              @in_ipv6_cidr_block_association_set = true
+            when 'ipv6CidrBlockState'
+              @in_cidr_block_state = true
             end
           end
 
           def end_element(name)
             if @in_tag_set
               case name
+              when 'item'
+                @subnet['tagSet'][@tag['key']] = @tag['value']
+                @tag = {}
+              when 'key', 'value'
+                @tag[name] = value
+              when 'tagSet'
+                @in_tag_set = false
+              end
+            elsif @in_ipv6_cidr_block_association_set
+              if @in_cidr_block_state
+                case name
+                when 'state'
+                  @ipv6_cidr_block_association['ipv6CidrBlockState'] = { name => value }
+                when 'ipv6CidrBlockState'
+                  @in_cidr_block_state = false
+                end
+              else
+                case name
                 when 'item'
-                  @subnet['tagSet'][@tag['key']] = @tag['value']
-                  @tag = {}
-                when 'key', 'value'
-                  @tag[name] = value
-                when 'tagSet'
-                  @in_tag_set = false
+                  @subnet['ipv6CidrBlockAssociationSet'] = @ipv6_cidr_block_association
+                  @ipv6_cidr_block_association = {}
+                when 'ipv6CidrBlock', 'associationId'
+                  @ipv6_cidr_block_association[name] = value
+                when 'ipv6CidrBlockAssociationSet'
+                  @in_ipv6_cidr_block_association_set = false
+                end
               end
             else
               case name


### PR DESCRIPTION
Hey,

Subnet's parsing was broken due to ipv6CidrBlockAssociationSet which include an `item` element and which was not taking in account, then the `item` element was taking in account for the subnet object instead of for the ipv6CidrBlockAssociationSet block.

Exemple:
*before*
```
{
    "subnetSet"=>
        [{
            "tagSet"=>{},
            "subnetId"=>"subnet-xxxxxxxx",
            "state"=>"associated",
            "vpcId"=>"vpc-xxxxxxxx",
            "cidrBlock"=>"172.31.1.0/16"
        },
        {   
            "tagSet"=>{"Name"=>"MyName"},
            "availableIpAddressCount"=>"X",
            "availabilityZone"=>"eu-west-1a",
            "defaultForAz"=>true,
            "mapPublicIpOnLaunch"=>true
        }],
    "requestId"=>"3173af67-7ba1-4193-ae67-9b00e1ca35f7"
```

*after*
```
{
    "subnetSet"=>
        [{
            "tagSet"=>{"Name"=>"MyName"},
            "subnetId"=>"subnet-xxxxxxxx",
            "state"=>"available",
            "vpcId"=>"vpc-xxxxxxxx",
            "cidrBlock"=>"172.31.1.0/16",
            "ipv6CidrBlockAssociationSet"=>
                {
                    "ipv6CidrBlock"=>"fd30:1270:0a36:20ed::/64",
                    "associationId"=>"subnet-cidr-assoc-xxxxxxxxxxxxxxxxx",
                    "ipv6CidrBlockState"=>{"state"=>"associated"}
                },
            "availableIpAddressCount"=>"X",
            "availabilityZone"=>"eu-west-1a",
            "defaultForAz"=>true,
            "mapPublicIpOnLaunch"=>true
        }],
    "requestId"=>"c9944ce5-c829-4e15-9335-3c8bfaca2bee
}
```

Documentation about this point: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html