### PR TITLE
Fix/sd 9632/missing implementation in listener parser

### DIFF
--- a/lib/fog/aws/parsers/elbv2/describe_listeners.rb
+++ b/lib/fog/aws/parsers/elbv2/describe_listeners.rb
@@ -6,12 +6,13 @@ module Fog
           def reset
             reset_listener
             @default_action = {}
+            @certificate = {}
             @results = { 'Listeners' => [] }
             @response = { 'DescribeListenersResult' => {}, 'ResponseMetadata' => {} }
           end
 
           def reset_listener
-            @listener= { 'DefaultActions' => [] }
+            @listener= { 'DefaultActions' => [], 'Certificates' => [] }
           end
 
           def start_element(name, attrs = [])
@@ -19,6 +20,8 @@ module Fog
             case name
             when 'DefaultActions'
               @in_default_actions = true
+            when 'Certificates'
+              @in_certificates = true
             end
           end
 
@@ -28,6 +31,9 @@ module Fog
               if @in_default_actions
                 @listener['DefaultActions'] << @default_action
                 @default_action = {}
+              elsif @in_certificates
+                @listener['Certificates'] << @certificate
+                @certificate = {}
               else
                 @results['Listeners'] << @listener
                 reset_listener
@@ -36,9 +42,13 @@ module Fog
               @listener[name] = value
             when 'Type', 'TargetGroupArn'
               @default_action[name] = value
+            when 'CertificateArn'
+              @certificate[name] = value
 
             when 'DefaultActions'
               @in_default_actions = false
+            when 'Certificates'
+              @in_certificates = false
 
             when 'RequestId'
               @response['ResponseMetadata'][name] = value

--- a/lib/fog/aws/parsers/elbv2/describe_listeners.rb
+++ b/lib/fog/aws/parsers/elbv2/describe_listeners.rb
@@ -54,9 +54,10 @@ module Fog
                 @target_group[name] = value
               when 'Type', 'Order'
                 @default_action[name] = value
-              when 'Path', 'Protocol', 'Port', 'Query', 'Host', 'StatusCode'
+              when 'Path', 'Protocol', 'Port', 'Query', 'Host', 'StatusCode', 'ContentType',
+                   'MessageBody', 'StatusCode'
                 @config[name] = value
-              when 'RedirectConfig', 'ForwardConfig'
+              when 'RedirectConfig', 'ForwardConfig', 'FixedResponseConfig'
                 @default_action[name] = @config
                 @config = {}
               when 'DurationSeconds', 'Enabled'

--- a/lib/fog/aws/parsers/elbv2/describe_listeners.rb
+++ b/lib/fog/aws/parsers/elbv2/describe_listeners.rb
@@ -52,7 +52,7 @@ module Fog
                 end
               when 'Weight'
                 @target_group[name] = value
-              when 'Type'
+              when 'Type', 'Order'
                 @default_action[name] = value
               when 'Path', 'Protocol', 'Port', 'Query', 'Host', 'StatusCode'
                 @config[name] = value
@@ -84,7 +84,7 @@ module Fog
                   @results['Listeners'] << @listener
                   reset_listener
                 end
-              when 'LoadBalancerArn', 'Protocol', 'Port', 'ListenerArn'
+              when 'LoadBalancerArn', 'Protocol', 'Port', 'ListenerArn', 'SslPolicy'
                 @listener[name] = value
               when 'CertificateArn'
                 @certificate[name] = value

--- a/tests/parsers/elbv2/describe_listeners_tests.rb
+++ b/tests/parsers/elbv2/describe_listeners_tests.rb
@@ -7,7 +7,7 @@ DESCRIBE_LISTENERS_RESULT = <<-EOF
     <Listeners>
       <member>
         <LoadBalancerArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188</LoadBalancerArn>
-        <Protocol>HTTP</Protocol>
+        <Protocol>HTTPS</Protocol>
         <Port>80</Port>
         <ListenerArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2</ListenerArn>
         <DefaultActions>
@@ -16,6 +16,11 @@ DESCRIBE_LISTENERS_RESULT = <<-EOF
             <TargetGroupArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067</TargetGroupArn>
           </member>
         </DefaultActions>
+        <Certificates>
+          <member>
+            <CertificateArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:certificate/56d36256-1245-40d6-916e-6f5a95e2b4c6</CertificateArn>
+          </member>
+        </Certificates>
       </member>
     </Listeners>
   </DescribeListenersResult>

--- a/tests/parsers/elbv2/describe_listeners_tests.rb
+++ b/tests/parsers/elbv2/describe_listeners_tests.rb
@@ -10,9 +10,11 @@ DESCRIBE_LISTENERS_RESULT = <<-EOF
         <Protocol>HTTPS</Protocol>
         <Port>80</Port>
         <ListenerArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2</ListenerArn>
+        <SslPolicy>polucy</SslPolicy>
         <DefaultActions>
           <member>
             <Type>forward</Type>
+            <Order>1</Order>
             <TargetGroupArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067</TargetGroupArn>
             <RedirectConfig>
               <Protocol>HTTPS</Protocol>
@@ -36,9 +38,11 @@ DESCRIBE_LISTENERS_RESULT = <<-EOF
         <Protocol>HTTPS</Protocol>
         <Port>80</Port>
         <ListenerArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2</ListenerArn>
+        <SslPolicy>polucy</SslPolicy>
         <DefaultActions>
           <member>
             <Type>forward</Type>
+            <Order>2</Order>
             <TargetGroupArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067</TargetGroupArn>
             <ForwardConfig>
               <TargetGroupStickinessConfig><Enable>true</Enable></TargetGroupStickinessConfig>

--- a/tests/parsers/elbv2/describe_listeners_tests.rb
+++ b/tests/parsers/elbv2/describe_listeners_tests.rb
@@ -31,6 +31,30 @@ DESCRIBE_LISTENERS_RESULT = <<-EOF
           </member>
         </Certificates>
       </member>
+      <member>
+        <LoadBalancerArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188</LoadBalancerArn>
+        <Protocol>HTTPS</Protocol>
+        <Port>80</Port>
+        <ListenerArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2</ListenerArn>
+        <DefaultActions>
+          <member>
+            <Type>forward</Type>
+            <TargetGroupArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067</TargetGroupArn>
+            <ForwardConfig>
+              <TargetGroupStickinessConfig><Enable>true</Enable></TargetGroupStickinessConfig>
+              <TargetGroups>
+                <Weight>1</Weight>
+                <TargetGroupArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067</TargetGroupArn>
+              </TargetGroups>
+            </ForwardConfig>
+          </member>
+        </DefaultActions>
+        <Certificates>
+          <member>
+            <CertificateArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:certificate/56d36256-1245-40d6-916e-6f5a95e2b4c6</CertificateArn>
+          </member>
+        </Certificates>
+      </member>
     </Listeners>
   </DescribeListenersResult>
   <ResponseMetadata>

--- a/tests/parsers/elbv2/describe_listeners_tests.rb
+++ b/tests/parsers/elbv2/describe_listeners_tests.rb
@@ -14,6 +14,15 @@ DESCRIBE_LISTENERS_RESULT = <<-EOF
           <member>
             <Type>forward</Type>
             <TargetGroupArn>arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067</TargetGroupArn>
+            <RedirectConfig>
+              <Protocol>HTTPS</Protocol>
+              <Port>443</Port>
+              <Path>\#{path}</Path>
+              <Query>\#{query}</Query>
+              <Host>\#{host}</Host>
+              <StatusCode>HTTP_301</StatusCode>
+              <Type>redirect</Type>
+            </RedirectConfig>
           </member>
         </DefaultActions>
         <Certificates>

--- a/tests/requests/elbv2/helper.rb
+++ b/tests/requests/elbv2/helper.rb
@@ -35,7 +35,8 @@ class AWS
         "Order" => String,
         "TargetGroupArn" => String,
         "RedirectConfig" => Fog::Nullable::Hash,
-        "ForwardConfig" => Fog::Nullable::Hash
+        "ForwardConfig" => Fog::Nullable::Hash,
+        "FixedResponseConfig" => Fog::Nullable::Hash
       }]
 
       LISTENER = {

--- a/tests/requests/elbv2/helper.rb
+++ b/tests/requests/elbv2/helper.rb
@@ -30,12 +30,18 @@ class AWS
         'CreateLoadBalancerResult' => {'LoadBalancers' => [LOAD_BALANCER], 'NextMarker' => Fog::Nullable::String}
       })
 
+      LISTENER_DEFAULT_ACTIONS = [{
+        "Type" => String,
+        "TargetGroupArn" => String,
+        "RedirectConfig" => Fog::Nullable::Hash
+      }]
+
       LISTENER = {
         "LoadBalancerArn" => String,
         "Protocol" => String,
         "Port" => String,
         "ListenerArn" => String,
-        "DefaultActions" => [{"Type" => String, "TargetGroupArn" => String}],
+        "DefaultActions" => LISTENER_DEFAULT_ACTIONS,
         "Certificates" => [{"CertificateArn" => String}]
       }
 

--- a/tests/requests/elbv2/helper.rb
+++ b/tests/requests/elbv2/helper.rb
@@ -33,7 +33,8 @@ class AWS
       LISTENER_DEFAULT_ACTIONS = [{
         "Type" => String,
         "TargetGroupArn" => String,
-        "RedirectConfig" => Fog::Nullable::Hash
+        "RedirectConfig" => Fog::Nullable::Hash,
+        "ForwardConfig" => Fog::Nullable::Hash
       }]
 
       LISTENER = {

--- a/tests/requests/elbv2/helper.rb
+++ b/tests/requests/elbv2/helper.rb
@@ -26,12 +26,17 @@ class AWS
         'DescribeLoadBalancersResult' => {'LoadBalancers' => [LOAD_BALANCER], 'NextMarker' => Fog::Nullable::String}
       })
 
+      CREATE_LOAD_BALANCER = BASIC.merge({
+        'CreateLoadBalancerResult' => {'LoadBalancers' => [LOAD_BALANCER], 'NextMarker' => Fog::Nullable::String}
+      })
+
       LISTENER = {
         "LoadBalancerArn" => String,
         "Protocol" => String,
         "Port" => String,
         "ListenerArn" => String,
-        "DefaultActions" => [{"Type" => String, "TargetGroupArn" => String}]
+        "DefaultActions" => [{"Type" => String, "TargetGroupArn" => String}],
+        "Certificates" => [{"CertificateArn" => String}]
       }
 
       DESCRIBE_LISTENERS = BASIC.merge({

--- a/tests/requests/elbv2/helper.rb
+++ b/tests/requests/elbv2/helper.rb
@@ -32,6 +32,7 @@ class AWS
 
       LISTENER_DEFAULT_ACTIONS = [{
         "Type" => String,
+        "Order" => String,
         "TargetGroupArn" => String,
         "RedirectConfig" => Fog::Nullable::Hash,
         "ForwardConfig" => Fog::Nullable::Hash
@@ -42,6 +43,7 @@ class AWS
         "Protocol" => String,
         "Port" => String,
         "ListenerArn" => String,
+        "SslPolicy" => String,
         "DefaultActions" => LISTENER_DEFAULT_ACTIONS,
         "Certificates" => [{"CertificateArn" => String}]
       }


### PR DESCRIPTION
Hello,

In this PR I fix some specific behavior and enhance a little bit the ELBv2 Listener parser. What is done:

- Commit 1 & 2:
On the first commit I fix a behavior which cut the listener in two invalid part when we have a `Certificates` block due to unhandled block `member`.
In the second one I implement the `RedirectConfig` which is inside `DefaultActions` block.

Exemple:
*Before*
```
{
  "Listeners"=> [{
    "DefaultActions"=> [{"Type"=>"redirect"}],
    "LoadBalancerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188",
    "Protocol"=>"HTTPS",
    "Port"=>"443",
    "ListenerArn"=> "arn:aws:elasticloadbalancing:eu-west-1:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/9070ddaffe07a0e3"
  },
  {
    "DefaultActions"=>[],
    "LoadBalancerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188",
    "Protocol"=>"HTTPS"},
  {
    "DefaultActions"=>[{"Type"=>"fixed-response"}],
    "Port"=>"443",
    "ListenerArn"=>
    "arn:aws:elasticloadbalancing:eu-west-1:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/c87b4c62a721d443"
  }]
}

```
*After*
```
{
  "Listeners"=> [{
    "DefaultActions"=> [{
      "RedirectConfig"=> {
        "Path"=>"/\#{path}",
        "Protocol"=>"HTTPS",
        "Port"=>"443",
        "Query"=>"\#{query}",
        "Host"=>"\#{host}",
        "StatusCode"=>"404"
      },
      "Type"=>"redirect"
    }],
    "Certificates"=>[],
    "LoadBalancerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188",
    "Protocol"=>"HTTP",
    "Port"=>"80",
    "ListenerArn"=> "arn:aws:elasticloadbalancing:eu-west-1:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/9070ddaffe07a0e3"
  },
  {
    "DefaultActions"=>[{"Type"=>"fixed-response"}],
    Certificates"=> [{
      "CertificateArn"=>"arn:aws:acm:eu-west-1:123456789012:certificate/72c86946-46f1-4d9b-afd7-c7a0994e0235"
    }],
    "LoadBalancerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188",
    "Protocol"=>"HTTPS",
    "Port"=>"443",
    "ListenerArn"=> "arn:aws:elasticloadbalancing:eu-west-1:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/c87b4c62a721d443"
  }]
}
```

- Commit 3 & 4
In the commit 3 I added the `ForwardConfig` which is inside `DefaultActions` block.
In the commit 4 I enhance a little bit the parser with attributes "SslPolicy" and "DefaultActions' Order" which were missing

Exemple:
*Before*
```
{
  "Listeners"=> [{
    "DefaultActions"=> [{
      "TargetGroupArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:targetgroup/group/11ab56130ea916a2"
      },
      {
        "Type"=>"forward"
      }],
      "Certificates"=>[{"CertificateArn"=>"arn:aws:iam::123456789012:server-certificate/api.com"
    }],
    "LoadBalancerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load_balancer/b1776c3641b74641",
    "Protocol"=>"HTTPS",
    "Port"=>"444",
    "ListenerArn"=>
    "arn:aws:elasticloadbalancing:eu-west-1:123456789012:listener/app/my-load_balancer/b1776c3641b74641/88f30be197a8ea29"
  }]
}
```
*After*
```
{
  "Listeners"=> [{
    "DefaultActions"=> [{
      "TargetGroupArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:targetgroup/group/11ab56130ea916a2",
      "ForwardConfig"=> {
        "TargetGroupStickinessConfig"=>{"Enabled"=>"false"},
        "TargetGroups"=> [{
          "Weight"=>"1",
          "TargetGroupArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:targetgroup/group/11ab56130ea916a2"
        }]
      },
      "Type"=>"forward",
      "Order"=>"1"
    }],
    "Certificates"=>[{"CertificateArn"=>"arn:aws:iam::123456789012:server-certificate/api.com"}],
    "LoadBalancerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load_balancer/b1776c3641b74641",
    "Protocol"=>"HTTPS",
    "Port"=>"444",
    "ListenerArn"=>
    "arn:aws:elasticloadbalancing:eu-west-1:123456789012:listener/app/my-load_balancer/b1776c3641b74641/88f30be197a8ea29",
    "SslPolicy"=>"ELBSslPolicy"
  }]
}
```

- Commit 5
In this final commit I added the `ForwardConfig` which is inside `DefaultActions` block.
*Before*
```
{
  "Listeners"=> [{
    "DefaultActions"=>[{"Type"=>"fixed-response", "Order"=>"1"}],
    "Certificates"=>[{"CertificateArn"=>"arn:aws:iam::123456789012:server-certificate/api.com"}],
    "LoadBalancerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load_balancer/b1776c3641b74641",
    "Protocol"=>"HTTPS",
    "Port"=>"443",
    "ListenerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:listener/app/my-load_balancer/b1776c3641b74641/d6877897eef9945b",
    "SslPolicy"=>"ELBSslPolicy"
  }]
}
```
*After*
```
{
  "Listeners"=> [{
    "DefaultActions"=> [{
      "FixedResponseConfig"=>{"MessageBody"=>"Test Body", "ContentType"=>"text/plain", "StatusCode"=>"503"},
      "Type"=>"fixed-response",
      "Order"=>"1"
    }],
    "Certificates"=>[{"CertificateArn"=>"arn:aws:iam::123456789012:server-certificate/api.com"}],
    "LoadBalancerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load_balancer/b1776c3641b74641",
    "Protocol"=>"HTTPS",
    "Port"=>"443",
    "ListenerArn"=>"arn:aws:elasticloadbalancing:eu-west-1:123456789012:listener/app/my-load_balancer/b1776c3641b74641/d6877897eef9945b",
    "SslPolicy"=>"ELBSslPolicy"
  }]
}
```